### PR TITLE
Update type Report (report.go) by adding Weakness field

### DIFF
--- a/h1/report.go
+++ b/h1/report.go
@@ -69,6 +69,7 @@ type Report struct {
 	Activities               []Activity          `json:"activities,omitempty"`
 	Bounties                 []Bounty            `json:"bounties,omitempty"`
 	Summaries                []ReportSummary     `json:"summaries,omitempty"`
+	Weakness                 *Weakness           `json:"weakness,omitempty"`
 }
 
 // Helper types for JSONUnmarshal
@@ -107,6 +108,9 @@ type reportUnmarshalHelper struct {
 		Summaries struct {
 			Data []ReportSummary `json:"data"`
 		} `json:"summaries"`
+		Weakness struct {
+			Data *Weakness `json:"data"`
+		} `json:"weakness"`
 	} `json:"relationships"`
 }
 
@@ -131,6 +135,7 @@ func (r *Report) UnmarshalJSON(b []byte) error {
 	}
 	r.Bounties = helper.Relationships.Bounties.Data
 	r.Summaries = helper.Relationships.Summaries.Data
+	r.Weakness = helper.Relationships.Weakness.Data
 	return nil
 }
 

--- a/weakness.go
+++ b/weakness.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package h1
+
+import (
+	"encoding/json"
+)
+
+// Weakness represents a weakness object
+//
+// HackerOne API docs: https://api.hackerone.com/docs/v1#weakness
+type Weakness struct {
+	ID          *string    `json:"id"`
+	Type        *string    `json:"type"`
+	Name        *string    `json:"name"`
+	Description *string    `json:"description"`
+	ExternalID  *string    `json:"external_id"`
+	CreatedAt   *Timestamp `json:"created_at"`
+}
+
+// Helper types for JSONUnmarshal
+type weakness Weakness // Used to avoid recursion of JSONUnmarshal
+type weaknessUnmarshalHelper struct {
+	weakness
+	Attributes *weakness `json:"attributes"`
+}
+
+// UnmarshalJSON allows JSONAPI attributes and relationships to unmarshal cleanly.
+func (w *Weakness) UnmarshalJSON(b []byte) error {
+	var helper weaknessUnmarshalHelper
+	helper.Attributes = &helper.weakness
+	if err := json.Unmarshal(b, &helper); err != nil {
+		return err
+	}
+	*w = Weakness(helper.weakness)
+	return nil
+}

--- a/weakness.json
+++ b/weakness.json
@@ -1,0 +1,10 @@
+{
+  "id": "1337",
+  "type": "weakness",
+  "attributes": {
+    "name": "Cross-Site Request Forgery (CSRF)",
+    "description": "The web application does not, or can not, sufficiently verify whether a well-formed, valid, consistent request was intentionally provided by the user who submitted the request.",
+    "created_at": "2016-02-02T04:05:06.000Z",
+    "external_id": "cwe-352"
+  }
+}

--- a/weakness_test.go
+++ b/weakness_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package h1
+
+import (
+	"github.com/stretchr/testify/assert"
+
+	"testing"
+)
+
+func Test_Weakness(t *testing.T) {
+	var actual Weakness
+	loadResource(t, &actual, "tests/resources/weakness.json")
+	expected := Weakness{
+		ID:          String("1337"),
+		Type:        String(WeaknessType),
+		Name:        String("Cross-Site Request Forgery (CSRF)"),
+		Description: String("The web application does not, or can not, sufficiently verify whether a well-formed, valid, consistent request was intentionally provided by the user who submitted the request."),
+		ExternalID:  String("cwe-352"),
+		CreatedAt:   NewTimestamp("2016-02-02T04:05:06.000Z"),
+	}
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Hi Luke, 

I am working on the pwnies-hackerone repo, which uses hackeroni as an api to access HackerOne reports, at LinkedIn. I am in the process of updating that repo and realized hackeroni does not have access to the Weakness field in a HackerOne report. To maintain the consistency of my modification in pwnies-hackerone, I think adding Weakness as one of the fields in Report type would be the best solution. 

I hope to hear your review soon. 

Thank you,
Mia