### PR TITLE
Add support for report summary attachments

### DIFF
--- a/h1/report-summary.go
+++ b/h1/report-summary.go
@@ -36,13 +36,14 @@ const (
 //
 // HackerOne API docs: https://api.hackerone.com/docs/v1#report-summary
 type ReportSummary struct {
-	ID        *string    `json:"id"`
-	Type      *string    `json:"type"`
-	Content   *string    `json:"content"`
-	Category  *string    `json:"category"`
-	CreatedAt *Timestamp `json:"created_at"`
-	UpdatedAt *Timestamp `json:"updated_at"`
-	User      *User      `json:"user"`
+	ID          *string      `json:"id"`
+	Type        *string      `json:"type"`
+	Content     *string      `json:"content"`
+	Category    *string      `json:"category"`
+	CreatedAt   *Timestamp   `json:"created_at"`
+	UpdatedAt   *Timestamp   `json:"updated_at"`
+	User        *User        `json:"user"`
+	Attachments []Attachment `json:"attachments"`
 }
 
 // Helper types for JSONUnmarshal
@@ -54,6 +55,9 @@ type reportSummaryUnmarshalHelper struct {
 		User struct {
 			Data *User `json:"data"`
 		} `json:"user"`
+		Attachments struct {
+			Data []Attachment `json:"data"`
+		} `json:"attachments"`
 	} `json:"relationships"`
 }
 
@@ -66,5 +70,6 @@ func (r *ReportSummary) UnmarshalJSON(b []byte) error {
 	}
 	*r = ReportSummary(helper.reportSummary)
 	r.User = helper.Relationships.User.Data
+	r.Attachments = helper.Relationships.Attachments.Data
 	return nil
 }

--- a/h1/report-summary_test.go
+++ b/h1/report-summary_test.go
@@ -50,6 +50,17 @@ func Test_ReportSummary(t *testing.T) {
 			},
 			CreatedAt: NewTimestamp("2016-02-02T04:05:06.000Z"),
 		},
+		Attachments: []Attachment{
+			Attachment{
+				ID:          String("1337"),
+				Type:        String(AttachmentType),
+				FileName:    String("root.rb"),
+				ContentType: String("text/x-c++"),
+				FileSize:    Int(2873),
+				ExpiringURL: String("/system/attachments/files/000/001/337/original/root.rb?1454385906"),
+				CreatedAt:   NewTimestamp("2016-02-02T04:05:06.000Z"),
+			},
+		},
 	}
 	assert.Equal(t, expected, actual)
 }

--- a/h1/tests/resources/report-summary.json
+++ b/h1/tests/resources/report-summary.json
@@ -25,6 +25,21 @@
           }
         }
       }
+    },
+    "attachments": {
+      "data": [
+        {
+          "id": "1337",
+          "type": "attachment",
+          "attributes": {
+            "expiring_url": "/system/attachments/files/000/001/337/original/root.rb?1454385906",
+            "created_at": "2016-02-02T04:05:06.000Z",
+            "file_name": "root.rb",
+            "content_type": "text/x-c++",
+            "file_size": 2873
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Adding support for report summary attachments which are not included with the normal report attachments. Did some local testing, seems to work well